### PR TITLE
feat: Add stop server button to main activity UI

### DIFF
--- a/app/src/main/java/com/matanh/transfer/MainActivity.kt
+++ b/app/src/main/java/com/matanh/transfer/MainActivity.kt
@@ -66,6 +66,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var viewStatusIndicator: View
     private lateinit var tvNoFilesMessage: TextView
     private lateinit var btnStartServer: Button
+    private lateinit var btnStopServer: ImageButton
     private lateinit var shareHandler: ShareHandler
 
     private var fileServerService: FileServerService? = null
@@ -175,6 +176,7 @@ class MainActivity : AppCompatActivity() {
         tilIps   = findViewById(R.id.tilIps)
         actvIps  = findViewById(R.id.actvIps)
         btnCopyIp = findViewById(R.id.btnCopyIp)
+        btnStopServer = findViewById(R.id.btnStopServer)
         rvFiles = findViewById(R.id.rvFiles)
         fabUpload = findViewById(R.id.fabUpload)
         viewStatusIndicator = findViewById(R.id.viewStatusIndicator)
@@ -199,6 +201,12 @@ class MainActivity : AppCompatActivity() {
         btnStartServer.setOnClickListener {
             currentSelectedFolderUri?.let { startFileServer(it) }
                 ?: navigateToSettingsWithMessage(getString(R.string.select_shared_folder_prompt))
+        }
+        btnStopServer.setOnClickListener {
+            Intent(this, FileServerService::class.java).also { intent ->
+                intent.action = Constants.ACTION_STOP_SERVICE
+                startService(intent)
+            }
         }
     }
 
@@ -347,6 +355,7 @@ class MainActivity : AppCompatActivity() {
                             updateIpDropdown(emptyList(),getString(R.string.server_starting))
 
                             btnStartServer.visibility = View.GONE
+                            btnStopServer.visibility = View.GONE
                             btnCopyIp.visibility = View.INVISIBLE
                         }
 
@@ -373,6 +382,7 @@ class MainActivity : AppCompatActivity() {
                             updateIpDropdown(entries)
 
                             btnStartServer.visibility = View.GONE
+                            btnStopServer.visibility = View.VISIBLE
                             btnCopyIp.visibility = View.VISIBLE
                         }
 
@@ -391,6 +401,7 @@ class MainActivity : AppCompatActivity() {
                             )
                             updateIpDropdown(emptyList(),getString(R.string.waiting_for_network))
                             btnStartServer.visibility = View.VISIBLE
+                            btnStopServer.visibility = View.GONE
                             btnCopyIp.visibility = View.INVISIBLE
                         }
 
@@ -409,6 +420,7 @@ class MainActivity : AppCompatActivity() {
                             )
                             updateIpDropdown(emptyList(),getString(R.string.server_error_format))
                             btnStartServer.visibility = View.VISIBLE
+                            btnStopServer.visibility = View.GONE
                             btnCopyIp.visibility = View.INVISIBLE
                         }
                     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -90,11 +90,22 @@ app:layout_constraintEnd_toEndOf="parent">
         <ImageButton
             android:id="@+id/btnCopyIp"
             android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:src="@drawable/ic_copy"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:contentDescription="@string/copy_ip_description"
-        app:tint="@color/colorPrimary"/>
+            android:layout_height="48dp"
+            android:src="@drawable/ic_copy"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/copy_ip_description"
+            app:tint="@color/colorPrimary"/>
+        
+        <ImageButton
+            android:id="@+id/btnStopServer"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:src="@drawable/ic_stop_black"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/stop_server"
+            app:tint="@color/red"
+            android:visibility="gone"
+            tools:visibility="visible"/>
 
         <Button
             android:id="@+id/btnStartServer"
@@ -157,4 +168,4 @@ android:src="@drawable/ic_upload_device"
 android:contentDescription="@string/upload_file"
 app:tint="@color/white"/>
 
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
### Summary of Changes

- **Added a Stop Server Button:** A new `ImageButton` with the ID `btnStopServer` has been added to the `activity_main.xml` layout. This button is styled with a red stop icon to provide a clear visual cue for the server-stopping action.
- **Dynamic Visibility:** The button's visibility is managed dynamically within the `MainActivity.kt` file. It is shown only when the server is in a `Running` state and is hidden in all other states, such as `Starting`, `Stopped`, or `Error`.
- **Enhanced UI Logic:** The `observeServerState` function in `MainActivity.kt` has been updated to handle the visibility of both the new `btnStopServer` and the existing `btnStartServer`. The `btnStartServer` is now only visible when the server is not running, ensuring a clean and intuitive user interface.
- **Server Control:** Tapping the "Stop" button now sends a `Constants.ACTION_STOP_SERVICE` intent to the `FileServerService`, initiating a graceful shutdown of the Ktor server.

### PR Checklist

- [x] New button added to `activity_main.xml`.
- [x] Click listener implemented in `MainActivity.kt` to handle the stop action.
- [x] `observeServerState` logic updated to manage button visibility based on server status.
- [x] Functionality tested to ensure the server stops correctly upon button press.